### PR TITLE
Reset game state (+ navigation header)

### DIFF
--- a/src/assets/js/App.tsx
+++ b/src/assets/js/App.tsx
@@ -62,7 +62,12 @@ const App = () => {
             if (!phraseCharacters.includes(key)) {
                 // After (6) incorrect guesses, the game is over.
                 if (incorrectGuesses >= 5) {
-                    setModalContent(<GameOver phrase={phrase} />);
+                    setModalContent(
+                        <GameOver
+                            onButtonClick={handleResetClick}
+                            phrase={phrase}
+                        />,
+                    );
                     setIsGameOver(true);
                     setIsModalOpen(true);
                 }

--- a/src/assets/js/App.tsx
+++ b/src/assets/js/App.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 
+import Control from './components/Control';
 import GameOver from './components/Modal/Content/GameOver';
 import Hangman from './components/Hangman';
 import Keyboard from './components/Keyboard/Keyboard';
 import Modal from './components/Modal/Modal';
 import Phrase from './components/Phrase/Phrase';
+import ResetIcon from './components/Icon/ResetIcon';
 import TopBar from './components/Navigation/TopBar';
 import { KeysPressedContext } from './contexts';
+
+// Type aliases
+type ReactButtonHandler = React.MouseEventHandler<HTMLButtonElement>;
 
 // App-level styles
 const BODY_STYLES = 'bg-gray-100 flex flex-col min-h-screen';
@@ -35,11 +40,18 @@ const App = () => {
         null as React.ReactNode,
     );
 
+    // On clicking the reset button, reset the game state.
+    const handleResetClick: ReactButtonHandler = (event) => {
+        setKeysPressed([]);
+        setIncorrectGuesses(0);
+        setIsGameOver(false);
+        setIsModalOpen(false);
+        setModalContent(null);
+    };
+
     // On click, add the letter to the list of pressed keys, and
     // check if the letter is in the phrase.
-    const handleKeyClick: React.MouseEventHandler<HTMLButtonElement> = (
-        event,
-    ) => {
+    const handleKeyClick: ReactButtonHandler = (event) => {
         const key = (event.target as HTMLButtonElement)?.innerText;
         if (key && !keysPressed.includes(key)) {
             // Add the letter to the list of pressed keys.
@@ -65,7 +77,11 @@ const App = () => {
             <Modal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen}>
                 {modalContent}
             </Modal>
-            <TopBar />
+            <TopBar>
+                <Control onClick={handleResetClick}>
+                    <ResetIcon />
+                </Control>
+            </TopBar>
             <main className={MAIN_CONTENT_STYLES} id="main-content">
                 <Hangman incorrectGuesses={incorrectGuesses} />
                 <KeysPressedContext.Provider value={keysPressed}>

--- a/src/assets/js/App.tsx
+++ b/src/assets/js/App.tsx
@@ -41,7 +41,7 @@ const App = () => {
     );
 
     // On clicking the reset button, reset the game state.
-    const handleResetClick: ReactButtonHandler = (event) => {
+    const handleResetClick: ReactButtonHandler = () => {
         setKeysPressed([]);
         setIncorrectGuesses(0);
         setIsGameOver(false);

--- a/src/assets/js/App.tsx
+++ b/src/assets/js/App.tsx
@@ -5,9 +5,16 @@ import Hangman from './components/Hangman';
 import Keyboard from './components/Keyboard/Keyboard';
 import Modal from './components/Modal/Modal';
 import Phrase from './components/Phrase/Phrase';
+import TopBar from './components/Navigation/TopBar';
 import { KeysPressedContext } from './contexts';
 
-const MODAL_OPEN_STYLES = 'h-screen overflow-hidden';
+// App-level styles
+const BODY_STYLES = 'bg-gray-100 flex flex-col min-h-screen';
+const MODAL_OPEN_STYLES = BODY_STYLES + ' h-screen overflow-hidden';
+
+// Main content styles
+const MAIN_CONTENT_STYLES =
+    'bg-white drop-shadow flex flex-col flex-grow justify-center max-w-2xl mx-auto px-3 py-4 sm:p-6 space-y-6 sm:space-y-8 md:space-y-12';
 
 const App = () => {
     const phrase = 'guess the phrase'.toUpperCase();
@@ -54,11 +61,12 @@ const App = () => {
     };
 
     return (
-        <div className={isModalOpen ? MODAL_OPEN_STYLES : ''}>
+        <div className={isModalOpen ? MODAL_OPEN_STYLES : BODY_STYLES}>
             <Modal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen}>
                 {modalContent}
             </Modal>
-            <div className="space-y-12">
+            <TopBar />
+            <main className={MAIN_CONTENT_STYLES} id="main-content">
                 <Hangman incorrectGuesses={incorrectGuesses} />
                 <KeysPressedContext.Provider value={keysPressed}>
                     <Phrase phrase={phrase} />
@@ -67,7 +75,7 @@ const App = () => {
                         isDisabled={isGameOver}
                     />
                 </KeysPressedContext.Provider>
-            </div>
+            </main>
         </div>
     );
 };

--- a/src/assets/js/components/Control.tsx
+++ b/src/assets/js/components/Control.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-const BACKGROUND_STYLES = 'bg-black opacity-80 hover:opacity-50 text-white';
-const CONTAINER_STYLES = 'flex items-center justify-center rounded-full';
+const BACKGROUND_STYLES = 'bg-black hover:opacity-50 text-white';
+const CONTAINER_STYLES =
+    'flex items-center justify-center rounded-full text-2xl';
 const SIZE_STYLES = 'h-6 sm:h-8 md:h-9 p-0.5 sm:p-1 w-6 sm:w-8 md:w-9';
 const TRANSITION_STYLES = 'transition-all';
 

--- a/src/assets/js/components/Hangman.tsx
+++ b/src/assets/js/components/Hangman.tsx
@@ -75,6 +75,9 @@ const Hangman = ({ incorrectGuesses }: HangmanProps) => {
         const context = canvas.getContext('2d');
         if (!context) return;
 
+        // Clear the canvas.
+        context.clearRect(0, 0, canvas.width, canvas.height);
+
         drawGallow(context);
         if (incorrectGuesses < 1) return;
 

--- a/src/assets/js/components/Icon/CrossIcon.tsx
+++ b/src/assets/js/components/Icon/CrossIcon.tsx
@@ -8,7 +8,7 @@ type CrossIconProps = {
 
 const CrossIcon = ({
     color = 'currentColor',
-    size = 20,
+    size = 24,
     ...props
 }: CrossIconProps) => {
     return (

--- a/src/assets/js/components/Icon/ResetIcon.tsx
+++ b/src/assets/js/components/Icon/ResetIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+type ResetIconProps = {
+    className?: string;
+    color?: string;
+    size?: number;
+};
+
+const ResetIcon = ({
+    color = 'currentColor',
+    size = 24,
+    ...props
+}: ResetIconProps) => {
+    return (
+        <svg
+            fill={color}
+            height={size}
+            stroke={color}
+            viewBox="0 0 24 24"
+            width={size}
+        >
+            <path
+                d="M10.634-22.807c-.863-.86-3.978 2.257-3.117 3.116l3.586 3.587c-14.532.098-26.282 11.907-26.282 26.46 0 14.614 11.844 26.458 26.458 26.458 13.801 0 25.13-10.563 26.351-24.048.109-1.21-4.28-1.608-4.392-.397C32.224 23.6 22.777 32.404 11.279 32.404c-12.177 0-22.048-9.872-22.048-22.048 0-12.118 9.776-21.951 21.868-22.05L7.517-8.107c-.861.858 2.254 3.978 3.117 3.116l7.348-7.349a2.194 2.194 0 0 0 0-3.116l-7.348-7.351Z"
+                transform="matrix(.36 0 0 .34 8 8.75)"
+            />
+        </svg>
+    );
+};
+
+export default ResetIcon;

--- a/src/assets/js/components/Icon/ResetIcon.tsx
+++ b/src/assets/js/components/Icon/ResetIcon.tsx
@@ -6,11 +6,7 @@ type ResetIconProps = {
     size?: number;
 };
 
-const ResetIcon = ({
-    color = 'currentColor',
-    size = 24,
-    ...props
-}: ResetIconProps) => {
+const ResetIcon = ({ color = 'currentColor', size = 24 }: ResetIconProps) => {
     return (
         <svg
             fill={color}

--- a/src/assets/js/components/Modal/Button.tsx
+++ b/src/assets/js/components/Modal/Button.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+const BACKGROUND_STYLES = 'bg-black hover:opacity-50';
+const CONTAINER_STYLES = 'rounded-full text-white';
+const SIZE_STYLES = 'p-2';
+const TRANSITION_STYLES = 'transition-all';
+
+type ButtonProps = {
+    children: React.ReactNode;
+    extraClasses?: string;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+};
+
+const Button = ({ children, extraClasses, onClick }: ButtonProps) => {
+    const styles = [
+        BACKGROUND_STYLES,
+        CONTAINER_STYLES,
+        SIZE_STYLES,
+        TRANSITION_STYLES,
+        extraClasses,
+    ];
+    return (
+        <button className={styles.join(' ')} onClick={onClick}>
+            {children}
+        </button>
+    );
+};
+
+export default Button;

--- a/src/assets/js/components/Modal/Content/GameOver.tsx
+++ b/src/assets/js/components/Modal/Content/GameOver.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import Button from '../Button';
 
 type GameOverProps = {
+    onButtonClick?: React.MouseEventHandler<HTMLButtonElement>;
     phrase: string;
 };
 
-const GameOver = ({ phrase }: GameOverProps) => {
+const GameOver = ({ onButtonClick, phrase }: GameOverProps) => {
     return (
         <div>
             <h1 className="mb-4 font-bold text-4xl text-center">Game Over</h1>
@@ -18,6 +19,12 @@ const GameOver = ({ phrase }: GameOverProps) => {
                 <br aria-hidden={true} />
                 &ldquo;<span className="font-bold">{phrase}</span>&rdquo;
             </p>
+            <Button
+                extraClasses="block max-w-xs mt-8 mx-auto w-full"
+                onClick={onButtonClick}
+            >
+                Play Again
+            </Button>
         </div>
     );
 };

--- a/src/assets/js/components/Navigation/TopBar.tsx
+++ b/src/assets/js/components/Navigation/TopBar.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import Control from '../Control';
-
 const CONTENT_STYLES =
     'flex items-center justify-between max-w-2xl mx-auto px-4 py-2 md:py-3';
 

--- a/src/assets/js/components/Navigation/TopBar.tsx
+++ b/src/assets/js/components/Navigation/TopBar.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import Control from '../Control';
+
+const CONTENT_STYLES =
+    'flex items-center justify-between max-w-2xl mx-auto px-4 py-2 md:py-3';
+
+const SKIP_STYLES =
+    'absolute bg-white border-2 border-black left-0 p-2 top-0 -translate-x-full focus:translate-x-0';
+
+type TopBarProps = {
+    children?: React.ReactNode;
+};
+
+const TopBar = ({ children }: TopBarProps) => {
+    return (
+        <header className="bg-white border-b-2 border-black relative">
+            <a className={SKIP_STYLES} href="#main-content">
+                Skip to phrase
+            </a>
+
+            <div className={CONTENT_STYLES}>
+                {/* Left */}
+                <h1 className="font-bold text-xl sm:text-2xl md:text-3xl">
+                    Hangman
+                </h1>
+
+                {/* Right */}
+                <div className="flex space-x-2 md:space-x-3">{children}</div>
+            </div>
+        </header>
+    );
+};
+
+export default TopBar;


### PR DESCRIPTION
This PR aims to allow players to reset the game state. This includes:

- adding a button (new component) to the Game Over modal,
- adding a control button in the top bar navigation (new component), and
- adding a handler to reset the game state when these buttons are clicked.

Other changes include minor tweaks to existing components.

<details><summary>Screenshots</summary>

![image](https://github.com/SharmaineLim/hangman/assets/5073278/a10b7c87-fb82-4f4c-a2c3-704f5e4d180e)

![image](https://github.com/SharmaineLim/hangman/assets/5073278/37d40a7e-c522-4dd1-a7a7-7abaa2b289cf)

</details>